### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-#webp
-##webp for all! (Android devices)
+# webp
+## webp for all! (Android devices)
 
 webp is a library we use at EverythingMe Launcher since we love webp. We use it to save bandwidth as well as shrinking our APK sizes.
 
 webp is an adaptation of chromium's webp decoder, and an addition of a JNI wrapper to easily use it it in your java code.
 
-##compile
+## compile
 just `gradle clean build`, and add the output aar to your libs (a public aar will be available soon)
 
-##How to use it?
+## How to use it?
 
 ```java
 import me.everything.webp.WebPDecoder
@@ -16,7 +16,7 @@ import me.everything.webp.WebPDecoder
 Bitmap bitmap = WebPDecoder.getInstance().decodeWebP(bytes);
 ```
 
-##WebpImageView
+## WebpImageView
 We also made it easy to load webp images from xml to an ImageView
 
 ```xml


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
